### PR TITLE
Makes maps responsively crop to centre

### DIFF
--- a/core/components/locationresources/elements/chunks/locationresourcesscript.chunk.tpl
+++ b/core/components/locationresources/elements/chunks/locationresourcesscript.chunk.tpl
@@ -33,4 +33,9 @@
             });
         }
     }
+	google.maps.event.addDomListener(window, "resize", function() {
+		var center = lrMap[[+docid]].getCenter();
+		google.maps.event.trigger(lrMap[[+docid]], "resize");
+		lrMap[[+docid]].setCenter(center);
+	});
 </script>


### PR DESCRIPTION
By default maps crop to the top, left corner when their bounding box is resized. This additional code block ensures they size against whatever is centred when the resize takes place.

Includes docid calls to be compatible with pull request relating to issue #3 - multiple maps on a page.