### PR TITLE
Resolve duplicate DIV IDs

### DIFF
--- a/core/components/locationresources/model/locationresources/locationresources.class.php
+++ b/core/components/locationresources/model/locationresources/locationresources.class.php
@@ -96,7 +96,7 @@ class LocationResources {
         if($error != false) return $error;
         
         // Check if docid has already been used as a DIV id and if it has, start incrementing
-	$proposedDIVID = "lr_map" . $docid;
+        $proposedDIVID = "lr_map" . $docid;
         $baseID = $docid;
 		if(strpos($this->modx->getRegisteredClientStartupScripts(),$proposedDIVID)!==FALSE) {
 	        for($i=1;$i<99;$i++) {

--- a/core/components/locationresources/model/locationresources/locationresources.class.php
+++ b/core/components/locationresources/model/locationresources/locationresources.class.php
@@ -96,7 +96,7 @@ class LocationResources {
         if($error != false) return $error;
         
         // Check if docid has already been used as a DIV id and if it has, start incrementing
-		$proposedDIVID = "lr_map" . $docid;
+	$proposedDIVID = "lr_map" . $docid;
         $baseID = $docid;
 		if(strpos($this->modx->getRegisteredClientStartupScripts(),$proposedDIVID)!==FALSE) {
 	        for($i=1;$i<99;$i++) {

--- a/core/components/locationresources/model/locationresources/locationresources.class.php
+++ b/core/components/locationresources/model/locationresources/locationresources.class.php
@@ -94,6 +94,19 @@ class LocationResources {
         // Check for GMaps API Key and add lib to head.
         $error = $this->initializeMap();
         if($error != false) return $error;
+        
+        // Check if docid has already been used as a DIV id and if it has, start incrementing
+		$proposedDIVID = "lr_map" . $docid;
+        $baseID = $docid;
+		if(strpos($this->modx->getRegisteredClientStartupScripts(),$proposedDIVID)!==FALSE) {
+	        for($i=1;$i<99;$i++) {
+		        $proposedDIVID = "lr_map" . $baseID . "_" . $i;
+		        if(strpos($this->modx->getRegisteredClientStartupScripts(),$proposedDIVID)===FALSE) {
+			        $docid = $baseID . "_" . $i;
+			        break;
+		        }
+	        }
+        }
 
         // Get chunks and return errors if missing.
         if(!$map = $this->modx->getChunk($tpl,array('lr.docid'=>$docid))) return 'Error: Unable to find the locationResourcesTpl chunk!';


### PR DESCRIPTION
This update checks against the code registered for the MODX Startup block for the proposed ID and if it exists, begins incrementing with the suffix '-#' until it finds a vacant spot. Taps out at 99, but I figure that's reasonable since 99 of the same map on the same page seems like a weird place to find useful.

The limit (at line 102) could be pushed to 999 or 9999 to put it beyond all doubt.